### PR TITLE
Check wether the payment method has been configured to use components before throwing error

### DIFF
--- a/Model/PaymentAdditionalDataProvider.php
+++ b/Model/PaymentAdditionalDataProvider.php
@@ -18,6 +18,8 @@ use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Payment\Gateway\Config\Config;
 use Magento\QuoteGraphQl\Model\Cart\Payment\AdditionalDataProviderInterface;
 use MultiSafepay\Api\Issuers\Issuer;
+use MultiSafepay\ConnectAdminhtml\Model\Config\Source\PaymentTypes;
+use MultiSafepay\ConnectCore\Model\Api\Builder\OrderRequestBuilder\TransactionTypeBuilder;
 use MultiSafepay\ConnectCore\Model\Ui\Gateway\IdealConfigProvider;
 use MultiSafepay\ConnectCore\Model\Ui\Gateway\MyBankConfigProvider;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -72,7 +74,7 @@ class PaymentAdditionalDataProvider implements AdditionalDataProviderInterface
     public function getData(array $data): array
     {
         $this->paymentConfig->setMethodCode($this->providerCode);
-        if (!isset($data[$this->providerCode]) && ($this->paymentConfig->getValue('payment_type') ?? $this->paymentConfig->getValue('transaction_type') ?? 'undefined') !== 'redirect') {
+        if (!isset($data[$this->providerCode]) && (($this->paymentConfig->getValue('payment_type') ?? '') === PaymentTypes::PAYMENT_COMPONENT_PAYMENT_TYPE || ($this->paymentConfig->getValue('transaction_type') ?? '') === TransactionTypeBuilder::TRANSACTION_TYPE_DIRECT_VALUE)) {
             throw new GraphQlInputException(
                 __(
                     'Required parameter "%1" for "payment_method" is missing.',


### PR DESCRIPTION
Fixes: #7 

Provided are 2 flavours.
This one, is checking if the type is related to using the components and if require the additional data instead of always requiring it.
However e.g. IDEAL can still redirect but does not have such configuration options.

Thus it may still throw an error if we want to redirect to multisafepay.

For this i've created https://github.com/MultiSafepay/magento2-graphql/pull/8