### PR TITLE
dont require payment components as redirect is still possible

### DIFF
--- a/Model/PaymentAdditionalDataProvider.php
+++ b/Model/PaymentAdditionalDataProvider.php
@@ -63,16 +63,7 @@ class PaymentAdditionalDataProvider implements AdditionalDataProviderInterface
      */
     public function getData(array $data): array
     {
-        if (!isset($data[$this->providerCode])) {
-            throw new GraphQlInputException(
-                __(
-                    'Required parameter "%1" for "payment_method" is missing.',
-                    $this->providerCode
-                )
-            );
-        }
-
-        $additionalData = $data[$this->providerCode];
+        $additionalData = $data[$this->providerCode] ?? [];
 
         if ($this->providerCode === IdealConfigProvider::CODE || $this->providerCode === MyBankConfigProvider::CODE) {
             $this->validateIssuerId($additionalData);


### PR DESCRIPTION
Fixes: #7 

Provided are 2 flavours.
This one will always allow the additional data to be missing and will redirect in that case.

Maybe we do want to force the components
For this i've created https://github.com/MultiSafepay/magento2-graphql/pull/8